### PR TITLE
:building_construction: Improvements for supporting dev function app and local dev

### DIFF
--- a/.funcignore
+++ b/.funcignore
@@ -15,3 +15,4 @@ scratch.js
 .devcontainer
 sample-data/
 readme-images/
+example.local.settings.json

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,6 +16,7 @@ on:
       - "sample-data/**"
       - "readme-images/**"
       - ".github/dependabot.yml"
+      - "example.local.settings.json"
 
 env:
   NODE_VERSION: 14.x # set this to the node version to use (supports 10.x, 12.x, 14.x)

--- a/.github/workflows/dev-build-and-deploy.yml
+++ b/.github/workflows/dev-build-and-deploy.yml
@@ -15,6 +15,7 @@ on:
       - "sample-data/**"
       - "readme-images/**"
       - ".github/dependabot.yml"
+      - "example.local.settings.json"
 
 env:
   NODE_VERSION: 14.x # set this to the node version to use (supports 10.x, 12.x, 14.x)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ as an [AdaptiveCard](https://adaptivecards.io/explorer/) and then sends it to an
       - Gives most important info at a glance
       - Color bar changes based on alert type and number of peers affected
       - Button to go view the alert in the Azure Portal
+    - Additional Notes/Requirements
+      - Manages state using a JSON file (kept in Blob Storage inside the Function App's existing storage account)
+      - You can specify the blob container (useful for dev vs prod) by setting an environment variable: `BLOB_CONTAINER_NAME`
+        - Uses default value of `functions-data` if `BLOB_CONTAINER_NAME` is not provided
     - Examples
       - Primary Down
         ![express-route-alert-one.png](./readme-images/express-route-alert-one.png)
@@ -98,6 +102,8 @@ as an [AdaptiveCard](https://adaptivecards.io/explorer/) and then sends it to an
    - **OPTIONAL**
      - `MS_TEAMS_DEV_WEBHOOK_URL`
        - URL of MS Teams Incoming Webhook to be used for unsupported payloads and development - if not provided, function will fall back to `MS_TEAMS_NOTIFICATION_WEBHOOK_URL`
+     - `BLOB_CONTAINER_NAME`
+       - Name of the Azure Blob container to use for storing state files - defaults to `functions-data`
      - `LOCAL_DEV`
        - Set to `true` to override alert and notification webhooks during development
        - Make sure to also set up `MS_TEAMS_DEV_WEBHOOK_URL` with a value or it will fall back to `MS_TEAMS_NOTIFICATION_WEBHOOK_URL`

--- a/example.local.settings.json
+++ b/example.local.settings.json
@@ -1,0 +1,21 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "APPINSIGHTS_INSTRUMENTATIONKEY": "your-appinsights-instrumentation-key",
+    "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=your-appinsights-instrumentation-key;IngestionEndpoint=https://your-region.in.applicationinsights.azure.com/",
+    "AzureWebJobsStorage": "DefaultEndpointsProtocol=https;AccountName=your-function-app-name;AccountKey=your-account-key;EndpointSuffix=core.windows.net",
+    "FUNCTIONS_EXTENSION_VERSION": "~4",
+    "FUNCTIONS_WORKER_RUNTIME": "node",
+    "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING": "DefaultEndpointsProtocol=https;AccountName=your-function-app-name;AccountKey=your-account-key;EndpointSuffix=core.windows.net",
+    "WEBSITE_CONTENTSHARE": "your-content-share",
+    "WEBSITE_NODE_DEFAULT_VERSION": "~14",
+    "WEBSITE_RUN_FROM_PACKAGE": "1",
+    "WEBSITE_TIME_ZONE": "Eastern Standard Time",
+    "AzureWebJobsSecretStorageType": "Blob",
+    "MS_TEAMS_ALERT_WEBHOOK_URL": "https://your-domain.webhook.office.com/webhookb2/guid@guid/IncomingWebhook/webhook-id/guid",
+    "MS_TEAMS_DEV_WEBHOOK_URL": "https://your-domain.webhook.office.com/webhookb2/guid@guid/IncomingWebhook/webhook-id/guid",
+    "MS_TEAMS_NOTIFICATION_WEBHOOK_URL": "https://your-domain.webhook.office.com/webhookb2/guid@guid/IncomingWebhook/webhook-id/guid",
+    "BLOB_CONTAINER_NAME": "your-dev-blob-container-name",
+    "NODE_ENV": "development"
+  }
+}

--- a/lib/cards/expressRouteAlert.js
+++ b/lib/cards/expressRouteAlert.js
@@ -16,6 +16,7 @@ exports.messageCard = async (alertData) => {
     alertTargetIDs,
     alertRule,
   } = alertData.essentials;
+  const title = 'Azure ExpressRoute Alert';
   const timestamp = localizeDateTime(firedDateTime);
   const subscriptionId = alertId.split('/')[2];
   const newStatus = monitorCondition.toLowerCase() === 'resolved';
@@ -56,7 +57,7 @@ exports.messageCard = async (alertData) => {
         size: 'large',
         weight: 'bolder',
         spacing: 'none',
-        text: 'Azure ExpressRoute Alert',
+        text: process.env.NODE_ENV === 'development' ? `DEV ${title}` : title,
       },
     ],
   };

--- a/lib/cards/serviceHealthAlert.js
+++ b/lib/cards/serviceHealthAlert.js
@@ -11,6 +11,8 @@ exports.messageCard = (alertData) => {
   const timestamp = localizeDateTime(firedDateTime);
   const subscriptionId = alertId.split('/')[2];
 
+  const title = 'Azure Service Health Alert';
+
   const inicidentTypes = {
     Informational: 'accent',
     ActionRequired: 'warning',
@@ -41,7 +43,7 @@ exports.messageCard = (alertData) => {
         size: 'large',
         weight: 'bolder',
         spacing: 'none',
-        text: 'Azure Service Health Alert',
+        text: process.env.NODE_ENV === 'development' ? `DEV ${title}` : title,
       },
     ],
   };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,7 +14,7 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 dayjs.tz.setDefault('America/New_York');
 
-const { AzureWebJobsStorage } = process.env;
+const { AzureWebJobsStorage, BLOB_CONTAINER_NAME } = process.env;
 
 /**
  * getAdaptiveCardTemplate
@@ -102,9 +102,18 @@ exports.whichPeer = (dimensions) => {
  */
 exports.getPeersStatus = async () => {
   const blobServiceClient = await getBlobServiceClient(AzureWebJobsStorage);
+  console.log('BLOB_CONTAINER_NAME: ', BLOB_CONTAINER_NAME);
+  console.log(
+    'storageDefaults.blobContainerName: ',
+    storageDefaults.blobContainerName,
+  );
+  console.log(
+    'BLOB_CONTAINER_NAME || storageDefaults.blobContainerName: ',
+    BLOB_CONTAINER_NAME || storageDefaults.blobContainerName,
+  );
   const containerClient = await getBlobContainerClient(
     blobServiceClient,
-    storageDefaults.blobContainerName,
+    BLOB_CONTAINER_NAME || storageDefaults.blobContainerName,
   );
   const blobContent = await getBlobContent(
     containerClient,
@@ -136,7 +145,7 @@ exports.getPeerStatus = async ({ peersData = null, peer = 'Primary-IPv4' }) => {
 exports.setPeersStatus = async (peersData) => {
   await uploadFile({
     storageConnectionString: AzureWebJobsStorage,
-    blobContainerName: storageDefaults.blobContainerName,
+    blobContainerName: BLOB_CONTAINER_NAME || storageDefaults.blobContainerName,
     fileContent: peersData,
     fileName: storageDefaults.peersFileName,
   });


### PR DESCRIPTION
- Accept optional `BLOB_CONTAINER_NAME`
  - useful for separating state files for dev function app and/or local dev
- Prefix ER and ASH alerts with the work 'DEV' if `NODE_ENV` is set to `development`
- Updates README with notes about `BLOB_CONTAINER_NAME`
- Adds example `local.settings.json` used by function apps during local development
  - values scrubbed 
  - file named: `example.local.settings.json`
- Adds `example.local.settings.json` to `paths-ignore` in workflow files
  - changes to this file shouldn't kickoff builds in the future
- Adds `example.local.settings.json` to `.funcignore`
  - no reason for this to be deployed